### PR TITLE
Remove type check on identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.1.1 - 2018-11-06
+
+### Fixed
+
+- Remove type check that prevented non-class identifiers
+
 ## 1.1.0 - 2018-11-05
 
 ### Added

--- a/src/LazyHandler.php
+++ b/src/LazyHandler.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Northwoods\Middleware;
 
-use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -19,12 +18,6 @@ class LazyHandler implements RequestHandlerInterface
 
     public function __construct(ContainerInterface $container, string $handler)
     {
-        if (! is_subclass_of($handler, RequestHandlerInterface::class, true)) {
-            throw new InvalidArgumentException(
-                sprintf('%s does not implement %s', $handler, RequestHandlerInterface::class)
-            );
-        }
-
         $this->container = $container;
         $this->handler = $handler;
     }

--- a/src/LazyMiddleware.php
+++ b/src/LazyMiddleware.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Northwoods\Middleware;
 
-use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,12 +19,6 @@ class LazyMiddleware implements MiddlewareInterface
 
     public function __construct(ContainerInterface $container, string $middleware)
     {
-        if (! is_subclass_of($middleware, MiddlewareInterface::class, true)) {
-            throw new InvalidArgumentException(
-                sprintf('%s does not implement %s', $middleware, MiddlewareInterface::class)
-            );
-        }
-
         $this->container = $container;
         $this->middleware = $middleware;
     }

--- a/tests/LazyHandlerTest.php
+++ b/tests/LazyHandlerTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Northwoods\Middleware;
 
-use InvalidArgumentException;
 use Northwoods\Middleware\Fixture\Handler;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
@@ -28,14 +27,6 @@ class LazyHandlerTest extends TestCase
                 return new $id();
             }
         };
-    }
-
-    public function testVerifiesHandlerImplementation(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(self::class);
-
-        $handler = new LazyHandler($this->container, self::class);
     }
 
     public function testDefersToHandlerImplemention(): void

--- a/tests/LazyMiddlewareTest.php
+++ b/tests/LazyMiddlewareTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Northwoods\Middleware;
 
-use InvalidArgumentException;
 use Northwoods\Middleware\Fixture\Handler;
 use Northwoods\Middleware\Fixture\Middleware;
 use Nyholm\Psr7\ServerRequest;
@@ -29,14 +28,6 @@ class LazyMiddlewareTest extends TestCase
                 return new $id();
             }
         };
-    }
-
-    public function testVerifiesMiddlewareImplementation(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(self::class);
-
-        $middleware = new LazyMiddleware($this->container, self::class);
     }
 
     public function testDefersToMiddlewareImplemention(): void


### PR DESCRIPTION
Checking the type of container identifier is inconsistent with PSR-11, which allows for identifiers that are not class names. The correct solution is to enforce typing via the `resolve()` method.